### PR TITLE
Fixes logging when options are not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -842,8 +842,11 @@ Client.prototype._commitBallot = function (ballot, transaction, callback) {
 }
 
 Client.prototype._log = function (who, args) {
-  if (this.options.debugP) console.log(JSON.stringify({ who: who, what: args || {}, when: underscore.now() }, null, 2))
-  if (this.options.loggingP) this.logging.push({ who: who, what: args || {}, when: underscore.now() })
+  const debugP = this.options ? this.options.debugP : false
+  const loggingP = this.options ? this.options.loggingP : false
+
+  if (debugP) console.log(JSON.stringify({ who: who, what: args || {}, when: underscore.now() }, null, 2))
+  if (loggingP) this.logging.push({ who: who, what: args || {}, when: underscore.now() })
 }
 
 Client.prototype._updateRules = function (callback) {


### PR DESCRIPTION
now we are using different logic in getStateInfo that we used before
changed
`ledgerInfo.passphrase = state.properties.wallet.keychains.passphrase`
into
`ledgerInfo.passphrase = ledgerClient.prototype.getWalletPassphrase(state)`

And we are calling this before options are defined, so we need to handle this use case as well